### PR TITLE
Ignore CUDA warning in integration test for densenet

### DIFF
--- a/lab/processes/train_dnn_pytorch/densenet_test.py
+++ b/lab/processes/train_dnn_pytorch/densenet_test.py
@@ -16,6 +16,7 @@ vscode_config.read("lab/processes/config_test.ini")
 
 
 @pytest.mark.integration
+@pytest.mark.filterwarnings("ignore:CUDA initialization")
 def test_train_densenet_without_errors(temp_data_dir):
     """
     Runs train_densenet with a mock mlflow instance.


### PR DESCRIPTION
A minor fix to disable CUDA initialization warning in the integration test for train_densenet