### PR TITLE
docs(drone): docker images documentation

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -30,7 +30,7 @@ environment:
 
 steps:
   - name: prepare-data
-    image: terminus7/sci-toolkit-runner:1.1.2
+    image: konstellation/kdl-py:3.9-1.1.0
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: minio-key-id
@@ -43,7 +43,7 @@ steps:
         path: /shared-storage
 
   - name: train-standard-classifiers
-    image: terminus7/sci-toolkit-runner:1.1.2
+    image: konstellation/kdl-py:3.9-1.1.0
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: minio-key-id
@@ -56,7 +56,7 @@ steps:
         path: /shared-storage
 
   - name: train-pytorch-neural-net
-    image: terminus7/sci-toolkit-runner:1.1.2
+    image: konstellation/kdl-py:3.9-1.1.0
     environment:
       AWS_ACCESS_KEY_ID:
         from_secret: minio-key-id

--- a/README.md
+++ b/README.md
@@ -216,10 +216,10 @@ steps:
   ...
 ```
 
-There are two recomendations regarding which image to use:
+There are two recommendations regarding which image to use:
 
-1. Using an oficial runtime image. These images are used for runing the KDL Usertools and have everything you need to run your code. If using one of these images take in account that the first thing you would need to do in the drone pipeline is to install your custom dependencies (`pipenv install`). You can fin info about runtimes and their docker images inside KDL in the Usertools Settings section.
-2. Using a custom image. In this case the recomendation is to build a new layer inside the official runtime images adding whatever you need to run your expirents/trainings.
+1. Using an official runtime image. These images are used for running the KDL Usertools and have everything you need to run your code. If using one of these images take into account that the first thing you would need to do in the drone pipeline is to install your custom dependencies (`pipenv install`). You can find info about runtimes and their docker images inside KDL in the Usertools Settings section.
+2. Using a custom image. For this case it is recommended to build a new layer on top of the official runtime images adding whatever you need to run your experiments/trainings.
 
 ## Logging experiment results (MLflow)
 

--- a/README.md
+++ b/README.md
@@ -205,6 +205,22 @@ git push origin process-data-v0
 Note: If using an external repository (e.g. hosted on Github), a delay in synchronization between Gitea and the mirrored external repo may cause a delay in launching the pipeline on the Drone runners.
 This delay can be overcome by manually forcing a synchronization of the repository in the Gitea UI Settings.
 
+### Docker images for experiments & trainings
+
+In the `drone.yml` file you can specify the image that is going to be used for each pipeline step.
+
+```yml
+steps:
+  - name: prepare-data
+    image: konstellation/kdl-py:3.9-1.1.0
+  ...
+```
+
+There are two recomendations regarding which image to use:
+
+1. Using an oficial runtime image. These images are used for runing the KDL Usertools and have everything you need to run your code. If using one of these images take in account that the first thing you would need to do in the drone pipeline is to install your custom dependencies (`pipenv install`). You can fin info about runtimes and their docker images inside KDL in the Usertools Settings section.
+2. Using a custom image. In this case the recomendation is to build a new layer inside the official runtime images adding whatever you need to run your expirents/trainings.
+
 ## Logging experiment results (MLflow)
 
 To compare various experiments, and to inspect the effect of the model hyperparameters on the results obtained, you can use MLflow experiment tracking. 


### PR DESCRIPTION
## WHY

The drone images used by the pipelines are hardcoded in the drone template. These images were very outdated and we need to update them.

## WHAT

Update the drone images to one of the latest runtime images and document in the `README.md` the options available when choosing the best docker image to run drone pipelines 