### PR TITLE
Remove gitleaks hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,10 +12,3 @@ repos:
       - id: no-commit-to-branch
         args:
           - --branch=main
-
-  - repo: https://github.com/zricethezav/gitleaks
-    rev: "v8.15.2"
-    hooks:
-      - id: gitleaks
-        args:
-          - hook-config=--config .gitleaks.toml


### PR DESCRIPTION
Remove the gitleaks hook

## Description
The gitleaks pre-commit hook requires Go to be installed. Since (for the time being) user-tools do not have go installed this generates and error

## Motivation and Context
Remove a functionality that most users cannot execute and can generate unwanted errors

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other changes (ci configuration, documentation or any other kind of changes)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have created tests for my code changes, and the tests are passing.
- [x] I have executed the pre-commit hooks locally.
- [ ] My change requires a change to the documentation (create a new issue if the documentation has not been updated).
- [ ] I have updated the documentation accordingly.
